### PR TITLE
chore(core/specs): add missing skeleton files

### DIFF
--- a/packages/backend/engine/api/__main__.py
+++ b/packages/backend/engine/api/__main__.py
@@ -1,0 +1,3 @@
+"""Placeholder runner so you can do: python -m packages.backend.engine.api"""
+if __name__ == "__main__":
+    print("backend api placeholder runner")

--- a/packages/backend/engine/core/job_types.py
+++ b/packages/backend/engine/core/job_types.py
@@ -1,0 +1,11 @@
+"""Placeholder: JobType taxonomy (to be implemented later)."""
+from enum import Enum
+
+
+class JobType(str, Enum):
+    TASKLET = "tasklet"
+    WORKFLOW = "workflow"
+    STREAM = "stream"
+    MISSION = "mission"
+    BATCH = "batch"
+    CLUSTER = "cluster"

--- a/packages/backend/tests/contract/test_get_health_contract.py
+++ b/packages/backend/tests/contract/test_get_health_contract.py
@@ -1,0 +1,2 @@
+def test_placeholder_health_contract():
+    assert True

--- a/packages/backend/tests/contract/test_patch_streams_heartbeat_contract.py
+++ b/packages/backend/tests/contract/test_patch_streams_heartbeat_contract.py
@@ -1,0 +1,2 @@
+def test_placeholder_streams_heartbeat_contract():
+    assert True

--- a/packages/backend/tests/contract/test_post_agents_step_contract.py
+++ b/packages/backend/tests/contract/test_post_agents_step_contract.py
@@ -1,0 +1,2 @@
+def test_placeholder_agents_step_contract():
+    assert True

--- a/packages/backend/tests/contract/test_post_tools_llm_invoke_contract.py
+++ b/packages/backend/tests/contract/test_post_tools_llm_invoke_contract.py
@@ -1,0 +1,2 @@
+def test_placeholder_tools_llm_invoke_contract():
+    assert True

--- a/packages/specs/openapi/paths/v1_agents__id__step.yaml
+++ b/packages/specs/openapi/paths/v1_agents__id__step.yaml
@@ -1,0 +1,2 @@
+# placeholder
+# POST /v1/agents/{id}/step

--- a/packages/specs/openapi/paths/v1_health.yaml
+++ b/packages/specs/openapi/paths/v1_health.yaml
@@ -1,0 +1,2 @@
+# placeholder
+# GET /v1/health

--- a/packages/specs/openapi/paths/v1_streams__id__heartbeat.yaml
+++ b/packages/specs/openapi/paths/v1_streams__id__heartbeat.yaml
@@ -1,0 +1,2 @@
+# placeholder
+# PATCH /v1/streams/{id}/heartbeat

--- a/packages/specs/openapi/paths/v1_tools__llm.invoke.yaml
+++ b/packages/specs/openapi/paths/v1_tools__llm.invoke.yaml
@@ -1,0 +1,2 @@
+# placeholder
+# POST /v1/tools/llm.invoke


### PR DESCRIPTION
Adds empty placeholders for job types, API runner, OpenAPI path stubs (agents step, tools invoke, streams heartbeat, health), and matching contract test placeholders. No logic; does not touch existing dag_shapes.py.

------
https://chatgpt.com/codex/tasks/task_e_689e3bb530288323a20e76db1fafea60