### PR TITLE
chore(backend): add jobs controller skeleton (placeholder)

### DIFF
--- a/packages/backend/api/controllers/jobs.py
+++ b/packages/backend/api/controllers/jobs.py
@@ -1,0 +1,4 @@
+"""
+Placeholder: jobs endpoints (e.g., POST /v1/jobs for one-shot tasks like image smile detection).
+Implementation to be added later.
+"""


### PR DESCRIPTION
## Summary
- add placeholder jobs controller for future `/v1/jobs` endpoint

## Testing
- `ruff check packages/backend/api/controllers/jobs.py`
- `pytest packages/backend/tests`
- `pytest` *(fails: import file mismatch in edge adapter tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e3e3b60948323ba5bd7cad93481df