### PR TITLE
chore(backend/specs): add storage presign skeleton (placeholders only)

### DIFF
--- a/packages/backend/api/controllers/storage.py
+++ b/packages/backend/api/controllers/storage.py
@@ -1,0 +1,2 @@
+"""Placeholder: storage endpoints (e.g., POST /v1/storage/presign for upload URLs)."""
+# Implementation to be added later.

--- a/packages/backend/tests/contract/test_post_storage_presign_contract.py
+++ b/packages/backend/tests/contract/test_post_storage_presign_contract.py
@@ -1,0 +1,2 @@
+def test_placeholder_storage_presign_contract():
+    assert True

--- a/packages/specs/openapi/paths/v1_storage__presign.yaml
+++ b/packages/specs/openapi/paths/v1_storage__presign.yaml
@@ -1,0 +1,2 @@
+# placeholder
+# POST /v1/storage/presign


### PR DESCRIPTION
## Summary
- scaffold storage controller for presign endpoint
- stub OpenAPI path for POST /v1/storage/presign
- add placeholder contract test for storage presign

## Testing
- `pytest -q` *(fails: import file mismatch in edge adapter tests)*
- `pytest packages/backend/tests/contract/test_post_storage_presign_contract.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689e3fdb11bc83239c69801185b99da0