### PR TITLE
chore(backend): worker host & artifacts skeleton

### DIFF
--- a/packages/backend/api/controllers/jobs.py
+++ b/packages/backend/api/controllers/jobs.py
@@ -1,4 +1,2 @@
-"""
-Placeholder: jobs endpoints (e.g., POST /v1/jobs for one-shot tasks like image smile detection).
-Implementation to be added later.
-"""
+"""Placeholder: jobs endpoints (e.g., POST /v1/jobs, GET /v1/jobs/{id})."""
+# Implementation to be added later.

--- a/packages/backend/engine/artifacts/__init__.py
+++ b/packages/backend/engine/artifacts/__init__.py
@@ -1,0 +1,1 @@
+# placeholder package for artifact resolution & verification

--- a/packages/backend/engine/artifacts/resolver.py
+++ b/packages/backend/engine/artifacts/resolver.py
@@ -1,0 +1,2 @@
+"""Placeholder: resolve artifact digests to fetchable URLs/paths and verify signatures."""
+# Implementation to be added later.

--- a/packages/backend/engine/artifacts/sandbox.py
+++ b/packages/backend/engine/artifacts/sandbox.py
@@ -1,0 +1,2 @@
+"""Placeholder: sandbox runner (microVM/WASM) for executing artifacts safely."""
+# Implementation to be added later.

--- a/packages/backend/engine/tools/__init__.py
+++ b/packages/backend/engine/tools/__init__.py
@@ -1,0 +1,1 @@
+# placeholder package for tool interfaces/registry

--- a/packages/backend/engine/tools/base.py
+++ b/packages/backend/engine/tools/base.py
@@ -1,0 +1,2 @@
+"""Placeholder: tool interface used by plans (run_code, sensor, llm@proxy, etc.)."""
+# Implementation to be added later.

--- a/packages/backend/engine/tools/run_code.py
+++ b/packages/backend/engine/tools/run_code.py
@@ -1,0 +1,2 @@
+"""Placeholder: run_code tool adapter (loads artifact and executes entry)."""
+# Implementation to be added later.

--- a/packages/backend/engine/worker_host/__init__.py
+++ b/packages/backend/engine/worker_host/__init__.py
@@ -1,0 +1,1 @@
+# placeholder package for generic worker host

--- a/packages/backend/engine/worker_host/host.py
+++ b/packages/backend/engine/worker_host/host.py
@@ -1,0 +1,9 @@
+"""Placeholder: generic worker host.
+
+Intended responsibilities (later):
+- pull job messages from queue
+- resolve artifact by digest
+- run inside sandbox (microVM/WASM)
+- write result/publish events
+"""
+# Implementation to be added later.

--- a/packages/backend/engine/workers/image_worker.py
+++ b/packages/backend/engine/workers/image_worker.py
@@ -1,0 +1,2 @@
+"""Placeholder: image job worker loop (downloads pointer, batches, infers, writes result)."""
+# Implementation to be added later.

--- a/packages/backend/tests/unit/test_worker_host_placeholder.py
+++ b/packages/backend/tests/unit/test_worker_host_placeholder.py
@@ -1,0 +1,2 @@
+def test_worker_host_placeholder():
+    assert True


### PR DESCRIPTION
Adds placeholders for generic worker host, artifact resolver/sandbox, tool interface, example image worker, and jobs controller stub. No logic implemented.

------
https://chatgpt.com/codex/tasks/task_e_689e432fa3248323b446b22143609dcc